### PR TITLE
Moves scraping work into separate thread

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,8 @@ authors = ["Darin Minamoto <darinm223@gmail.com>"]
 serde = "0.9"
 serde_json = "0.9"
 serde_derive = "0.9"
-futures = "0.1.7"
+futures = "0.1"
+futures-cpupool = "0.1"
 tokio-core = "0.1"
 kuchiki = "0.4"
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Pokemon Showdown Recent Replay Service
 A web service written in Rust using Tokio and Hyper that returns
 the recent replays from Pokemon Showdown, mainly written
 to show how to write an asynchronous server that uses an asynchronous client
-to retrieve pages.
+to retrieve pages while moving computationally intensive work into separate threads.
 
 It handles requests to the root path by sending a request to the
 Pokemon Showdown replay page and returning the scraped recent replays in JSON format.

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,8 +17,8 @@ use hyper::client::{Client, HttpConnector};
 use hyper::header::ContentLength;
 use hyper::server::{Http, Request, Response, Service};
 use kuchiki::traits::*;
+use std::rc::Rc;
 use std::str;
-use std::sync::Arc;
 use tokio_core::net::TcpListener;
 use tokio_core::reactor::{Core, Handle};
 
@@ -37,14 +37,14 @@ struct ShowdownReplayService {
     /// Pokemon Showdown replay page.
     client: Client<HttpConnector>,
     /// Thread pool for running scraping work.
-    pool: Arc<CpuPool>,
+    pool: Rc<CpuPool>,
 }
 
 impl ShowdownReplayService {
     fn new(handle: Handle) -> ShowdownReplayService {
         ShowdownReplayService {
             client: Client::new(&handle),
-            pool: Arc::new(CpuPool::new(NUM_CPUS)),
+            pool: Rc::new(CpuPool::new(NUM_CPUS)),
         }
     }
 }


### PR DESCRIPTION
Moves the scraping work into a threadpool in order to not bog down the main event loop. Right now the threadpool contains 4 threads but it can be changed by modifying the NUM_CPUS constant.
I plan on merging this eventually since it provides a good example on how to move CPU work into other threads in an async web service but I'm documenting some benchmarks between the threaded and nonthreaded versions before I do so.

Benchmarks
=========

I used an HTTP benchmarking tool called wrk (https://github.com/wg/wrk) and ran 3 tests on the release builds for 30 seconds, using 4 threads, and keeping 100 HTTP connections open. For every test the threadpool benchmark was ran right after the non-threadpool benchmark (so there is very little time in between runs).

The results indicate that the service using a threadpool has more requests/second and less latency and timeouts than the service without the threadpool. That means that the service using a threadpool for scraping work may have better performance than the service doing everything on one thread.

## Test 1

Non thread pool:
```
Running 30s test @ http://127.0.0.1:1337
  4 threads and 100 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     1.12s   372.33ms   2.00s    62.01%
    Req/Sec    18.67     16.19   101.00     80.89%
  1466 requests in 30.08s, 4.27MB read
  Socket errors: connect 0, read 0, write 0, timeout 442
Requests/sec:     48.73
Transfer/sec:    145.20KB
```

Thread pool:
```
Running 30s test @ http://127.0.0.1:1337
  4 threads and 100 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   999.76ms  458.41ms   2.00s    56.15%
    Req/Sec    17.42     15.15   107.00     86.47%
  1666 requests in 30.09s, 4.87MB read
  Socket errors: connect 0, read 0, write 0, timeout 243
Requests/sec:     55.36
Transfer/sec:    165.63KB
```

## Test 2

Non thread pool:
```
Running 30s test @ http://127.0.0.1:1337
  4 threads and 100 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     1.01s   378.58ms   1.98s    64.43%
    Req/Sec    14.39     14.18    89.00     82.72%
  942 requests in 30.10s, 2.78MB read
  Socket errors: connect 0, read 0, write 0, timeout 450
Requests/sec:     31.30
Transfer/sec:     94.57KB
```

Thread pool:
```
Running 30s test @ http://127.0.0.1:1337
  4 threads and 100 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   973.43ms  473.40ms   1.97s    54.67%
    Req/Sec    16.31     12.65    90.00     72.51%
  1420 requests in 30.04s, 4.17MB read
  Socket errors: connect 0, read 0, write 0, timeout 370
Requests/sec:     47.27
Transfer/sec:    142.26KB
```

## Test 3

Non thread pool:
```
Running 30s test @ http://127.0.0.1:1337
  4 threads and 100 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     1.59s   351.18ms   2.00s    69.72%
    Req/Sec    13.13     13.39    97.00     85.23%
  918 requests in 30.09s, 2.72MB read
  Socket errors: connect 0, read 0, write 0, timeout 591
Requests/sec:     30.51
Transfer/sec:     92.60KB
```

Thread pool:
```
Running 30s test @ http://127.0.0.1:1337
  4 threads and 100 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     1.15s   443.30ms   1.99s    56.77%
    Req/Sec    16.63     15.46   100.00     83.69%
  1224 requests in 30.05s, 3.63MB read
  Socket errors: connect 0, read 0, write 0, timeout 419
Requests/sec:     40.73
Transfer/sec:    123.71KB
```